### PR TITLE
allow environment varibles

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/ash
-RTL_ARGS=""
-MOSQUITTO_ARGS=""
+[  -z "$RTL_ARGS" ] && RTL_ARGS=""
+[  -z "$MOSQUITTO_ARGS" ] && MOSQUITTO_ARGS=""
 
 for i in "$@" ; do
 case $i in


### PR DESCRIPTION
In order for the docker image to work within kubernetes the parameters for mqtt and rtl_433 need to be provided via env variables. This PR should do it without affecting existing method.