### PR TITLE
armv7 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 env:
   global:
-    - DOCKER_PLATFORMS="linux/amd64,linux/arm/v6,linux/arm64/v8"
+    - DOCKER_PLATFORMS="linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8"
     - DOCKER_COMMIT=${TRAVIS_COMMIT::6}
     - DOCKER_TAG="${TRAVIS_TAG}"
     - BUILDKIT_HOST=tcp://0.0.0.0:1234


### PR DESCRIPTION
Only way I could get the docker image running on a Raspberry pi 4 was with an armv7 build as per this PR. 